### PR TITLE
Various changes

### DIFF
--- a/PowerMeterTx.py
+++ b/PowerMeterTx.py
@@ -63,7 +63,6 @@ class PowerMeterTx(object):
         payload.append(self.powerData.instantaneousPower >> 8)
 
         ant_msg = message.ChannelBroadcastDataMessage(self.channel.number, data=payload)
-        sys.stdout.write('+')
-        sys.stdout.flush()
+        print(f'Power: {int(power)} W   \r', end="")
         if VPOWER_DEBUG: print('Write message to ANT stick on channel ' + repr(self.channel.number))
         self.antnode.send(ant_msg)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ or more.
 ![vPower unit with air density sensor](https://github.com/dhague/vpower/raw/master/images/vPowerPiZeroCase.JPG)
 
 If you're not bothered about the air density correction then you don't even need a Raspberry Pi - any computer running
-Linux will do (even a virtual machine running in Windows is fine) - all you need is a dedicated ANT+ USB stick.
+Linux or Windows will do - all you need is a dedicated ANT+ USB stick.
 
 The plan is to enhance the project further so that accelerations/decelerations can be factored in, increasing the 
 accuracy in the sub-10 second range and making the project useful for calculating sprint power.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,6 @@ You can turn on DEBUG/diagnostic output by setting `debug` to `True` in `vpower.
 
 1. Install the libusb-win32 driver for the ANT stick, it can be easily done using [Zadig](https://zadig.akeo.ie/).
 
-2. Install dependencies:
+2. Install pywin32 (optional, stops the ANT node on terminal window close):
 
-    `pip install configparser pywin32`
+    `pip install pywin32`

--- a/README.md
+++ b/README.md
@@ -149,3 +149,11 @@ You can turn on DEBUG/diagnostic output by setting `debug` to `True` in `vpower.
 2. Configure the service to start at boot time:
 
     `sudo update-rc.d vpower defaults`
+
+## Running on Windows
+
+1. Install the libusb-win32 driver for the ANT stick, it can be easily done using [Zadig](https://zadig.akeo.ie/).
+
+2. Install dependencies:
+
+    `pip install configparser pywin32`

--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ You should see something like this:
     Using KurtKineticPowerCalculator
     Starting power meter
     Main wait loop
-    +++++
+    Power: x W
 
-Each `+` corresponds to a power message being sent, so these will only appear once you start pedalling.
+The `x` corresponds to the power value in the message being sent, so it will only appear once you start pedalling.
 If you have a BME280 sensor attached then you will also see some data on temperature, pressure, humidity and air density
 and a `o` will occasionally appear when the air density is updated.
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ You can turn on DEBUG/diagnostic output by setting `debug` to `True` in `vpower.
 
 1. Install the libusb-win32 driver for the ANT stick, it can be easily done using [Zadig](https://zadig.akeo.ie/).
 
-2. Install pywin32 (optional, stops the ANT node on terminal window close):
+2. Clone or download this repo and install the required Python libraries:
+
+    `pip install -r requirements.txt`
+
+3. [optional] Install pywin32 (to stop the ANT node on terminal window close):
 
     `pip install pywin32`

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from CycleOpsFluid2PowerCalculator import CycleOpsFluid2PowerCalculator
 from constants import *
 import hashlib
 
-VPOWER_DEBUG = True
+VPOWER_DEBUG = False
 
 CONFIG = ConfigParser()
 _CONFIG_FILENAME = 'vpower.cfg'

--- a/constants.py
+++ b/constants.py
@@ -1,19 +1,26 @@
+import platform
+
 SPEED_DEVICE_TYPE = 0x7B
 CADENCE_DEVICE_TYPE = 0x7A
 SPEED_CADENCE_DEVICE_TYPE = 0x79
 POWER_DEVICE_TYPE = 0x0B
 
 
-# Get the serial number of Raspberry Pi
+# Get the serial number of Raspberry Pi or PC CPU (Windows)
 def getserial():
-    # Extract serial from cpuinfo file
     cpuserial = "0000000000000000"
     try:
-        f = open('/proc/cpuinfo', 'r')
-        for line in f:
-            if line[0:6] == 'Serial':
-                cpuserial = line[10:26]
-        f.close()
+        if platform.system() == 'Windows':
+            # Extract serial from wmic command
+            from subprocess import check_output
+            cpuserial = check_output('wmic cpu get ProcessorId').decode().split('\n')[1].strip()
+        else:
+            # Extract serial from cpuinfo file
+            f = open('/proc/cpuinfo', 'r')
+            for line in f:
+                if line[0:6] == 'Serial':
+                    cpuserial = line[10:26]
+            f.close()
     except:
         cpuserial = "ERROR000000000"
 

--- a/vpower.cfg
+++ b/vpower.cfg
@@ -2,10 +2,10 @@
 # Type of ANT+ speed sensor connected to the trainer
 # 121 (0x79) = Speed & Cadence sensor
 # 123 (0x7B) = Speed-only sensor
-speed_sensor_type = 121
+speed_sensor_type = 123
 
-# ANT+ ID of the above sensor
-speed_sensor_id: 24090
+# ANT+ ID of the above sensor (0 for auto scan)
+speed_sensor_id: 0
 
 # Calculator class for the model of turbo
 # BtAtsPowerCalculator           = Bike Technologies ATS

--- a/vpower.py
+++ b/vpower.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import time
+import platform
 
 from ant.core import driver
 from ant.core import node
@@ -13,6 +14,30 @@ from config import DEBUG, LOG, NETKEY, POWER_CALCULATOR, POWER_SENSOR_ID, SENSOR
 antnode = None
 speed_sensor = None
 power_meter = None
+
+def stop_ant():
+    if speed_sensor:
+        print("Closing speed sensor")
+        speed_sensor.close()
+        speed_sensor.unassign()
+    if power_meter:
+        print("Closing power meter")
+        power_meter.close()
+        power_meter.unassign()
+    if antnode:
+        print("Stopping ANT node")
+        antnode.stop()
+
+pywin32 = False
+if platform.system() == 'Windows':
+    def on_exit(sig, func=None):
+        stop_ant()
+    try:
+        import win32api
+        win32api.SetConsoleCtrlHandler(on_exit, True)
+        pywin32 = True
+    except ImportError:
+        print("Warning: pywin32 is not installed, use Ctrl+C to stop")
 
 try:
     print("Using " + POWER_CALCULATOR.__class__.__name__)
@@ -90,14 +115,5 @@ try:
 except Exception as e:
     print("Exception: " + repr(e))
 finally:
-    if speed_sensor:
-        print("Closing speed sensor")
-        speed_sensor.close()
-        speed_sensor.unassign()
-    if power_meter:
-        print("Closing power meter")
-        power_meter.close()
-        power_meter.unassign()
-    if antnode:
-        print("Stopping ANT node")
-        antnode.stop()
+    if not pywin32:
+        stop_ant()


### PR DESCRIPTION
- Continue trying if first stick can't be claimed. The patch to support multiple identical devices is already merged in https://github.com/mch/python-ant
- Workaround for some apps (namely RGT Cycling and GTBikeV).
- Print the sent value instead of plus sign on power updates.
- Get CPU serial on Windows.
- Stop ANT on console exit (Windows).